### PR TITLE
Add ancestor bookmark (with distance) display

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,28 @@ when = "jj-starship detect"
 
 ## Output Format
 
+### JJ Format
+
 ```
-on {symbol}{name} ({id}) [{status}]
+on {symbol}{change_id} ({bookmarks}) [{status}]
+```
+
+- `{change_id}` - Short change ID (hide with `--no-jj-id`)
+- `{bookmarks}` - Comma-separated bookmarks with distance, sorted by proximity (hide with `--no-jj-name`)
+  - Distance 0 (bookmark on WC): `main`
+  - Ancestor bookmark: `main~3` (3 commits behind)
+- `{status}` - Sync status based on **first/closest** bookmark only
+
+Examples:
+- `on 󱗆 yzxv1234 [?]` - No bookmarks
+- `on 󱗆 yzxv1234 (main) [?]` - On bookmark `main`
+- `on 󱗆 yzxv1234 (main~3) [?]` - 3 commits ahead of `main`
+- `on 󱗆 yzxv1234 (pr-3, pr-2~1, main~5)` - Direct + ancestor bookmarks
+
+### Git Format
+
+```
+on {symbol}{branch} ({commit}) [{status}]
 ```
 
 ### JJ Status Symbols
@@ -92,7 +112,7 @@ on {symbol}{name} ({id}) [{status}]
 | `!` | Conflict |
 | `?` | Empty description |
 | `⇔` | Divergent |
-| `⇡` | Unsynced with remote |
+| `⇡` | Current or closest bookmark unsynced with remote |
 
 ### Git Status Symbols
 
@@ -113,6 +133,7 @@ on {symbol}{name} ({id}) [{status}]
 | `--cwd <PATH>` | Override working directory |
 | `--truncate-name <N>` | Max branch/bookmark name length (0 = unlimited) |
 | `--id-length <N>` | Hash display length (default: 8) |
+| `--ancestor-bookmark-depth <N>` | Max depth to search for ancestor bookmarks (default: 10, 0 = disabled) |
 | `--jj-symbol <S>` | JJ repo symbol (default: `󱗆 `) |
 | `--git-symbol <S>` | Git repo symbol (default: ` `) |
 | `--no-color` | Disable output styling |
@@ -132,6 +153,7 @@ All options can be set via environment variables (CLI args take precedence):
 
 - `JJ_STARSHIP_TRUNCATE_NAME`
 - `JJ_STARSHIP_ID_LENGTH`
+- `JJ_STARSHIP_ANCESTOR_BOOKMARK_DEPTH`
 - `JJ_STARSHIP_JJ_SYMBOL`
 - `JJ_STARSHIP_GIT_SYMBOL`
 - `JJ_STARSHIP_NO_JJ_PREFIX`

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,8 @@ pub struct Config {
     pub truncate_name: usize,
     /// Length of `change_id/commit` hash to display
     pub id_length: usize,
+    /// Max depth to search for ancestor bookmarks (0 = disabled, default: 10)
+    pub ancestor_bookmark_depth: usize,
     /// Symbol prefix for JJ repos
     pub jj_symbol: Cow<'static, str>,
     /// Symbol prefix for Git repos
@@ -55,6 +57,7 @@ impl Default for Config {
         Self {
             truncate_name: 0, // unlimited
             id_length: 8,
+            ancestor_bookmark_depth: 10,
             jj_symbol: Cow::Borrowed(DEFAULT_JJ_SYMBOL),
             git_symbol: Cow::Borrowed(DEFAULT_GIT_SYMBOL),
             jj_display: DisplayConfig::all_visible(),
@@ -89,10 +92,11 @@ impl DisplayFlags {
 impl Config {
     /// Create config from CLI args and environment variables
     /// CLI args take precedence over env vars
-    #[allow(clippy::fn_params_excessive_bools)]
+    #[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
     pub fn new(
         truncate_name: Option<usize>,
         id_length: Option<usize>,
+        ancestor_bookmark_depth: Option<usize>,
         jj_symbol: Option<String>,
         git_symbol: Option<String>,
         no_symbol: bool,
@@ -106,6 +110,15 @@ impl Config {
         let id_length = id_length
             .or_else(|| env::var("JJ_STARSHIP_ID_LENGTH").ok()?.parse().ok())
             .unwrap_or(8);
+
+        let ancestor_bookmark_depth = ancestor_bookmark_depth
+            .or_else(|| {
+                env::var("JJ_STARSHIP_ANCESTOR_BOOKMARK_DEPTH")
+                    .ok()?
+                    .parse()
+                    .ok()
+            })
+            .unwrap_or(10);
 
         let (jj_symbol, git_symbol) = if no_symbol {
             (Cow::Borrowed(""), Cow::Borrowed(""))
@@ -122,6 +135,7 @@ impl Config {
         Self {
             truncate_name,
             id_length,
+            ancestor_bookmark_depth,
             jj_symbol,
             git_symbol,
             jj_display: jj_flags.into_config("JJ_STARSHIP_NO_JJ"),

--- a/src/jj.rs
+++ b/src/jj.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, Result};
 use jj_lib::config::{ConfigLayer, ConfigSource, StackedConfig};
 use jj_lib::hex_util::encode_reverse_hex;
 use jj_lib::object_id::ObjectId;
+use jj_lib::ref_name::RefName;
 use jj_lib::repo::{Repo, StoreFactories};
 use jj_lib::settings::UserSettings;
 use jj_lib::str_util::{StringMatcher, StringPattern};
@@ -17,17 +18,18 @@ use std::sync::Arc;
 pub struct JjInfo {
     /// Short change ID (8 chars)
     pub change_id: String,
-    /// Bookmark name if WC is on one
-    pub bookmark: Option<String>,
+    /// Bookmarks with distances: vec of (name, distance). Empty if none found.
+    /// Distance 0 = directly on WC, 1+ = ancestor distance
+    pub bookmarks: Vec<(String, usize)>,
     /// Description is empty (needs commit message)
     pub empty_desc: bool,
     /// Has conflicts in tree
     pub conflict: bool,
     /// Multiple commits for same `change_id`
     pub divergent: bool,
-    /// Bookmark exists on a remote
+    /// Whether any bookmark has a remote
     pub has_remote: bool,
-    /// Local bookmark == remote bookmark
+    /// Whether any bookmark is synced with remote
     pub is_synced: bool,
 }
 
@@ -48,8 +50,117 @@ fn create_user_settings() -> Result<UserSettings> {
     UserSettings::from_config(config).map_err(|e| Error::Jj(format!("settings: {e}")))
 }
 
+/// Find immutable head commits (trunk + tags + untracked remote bookmarks)
+/// Mirrors jj's `builtin_immutable_heads()` without revset evaluation
+fn find_immutable_heads(view: &jj_lib::view::View) -> std::collections::HashSet<jj_lib::backend::CommitId> {
+    use std::collections::HashSet;
+
+    let mut immutable = HashSet::new();
+
+    // Single pass over all remote bookmarks
+    for (symbol, remote_ref) in view.remote_bookmarks_matching(&StringMatcher::All, &StringMatcher::All) {
+        let name = symbol.name.as_str();
+        let remote = symbol.remote.as_str();
+
+        if remote == "git" {
+            continue;
+        }
+
+        // trunk: main/master/trunk on origin/upstream
+        let is_trunk =
+            matches!(remote, "origin" | "upstream") && matches!(name, "main" | "master" | "trunk");
+
+        // untracked: no local counterpart
+        let is_untracked = view.get_local_bookmark(symbol.name).is_absent();
+
+        if is_trunk || is_untracked {
+            if let Some(id) = remote_ref.target.as_normal() {
+                immutable.insert(id.clone());
+            }
+        }
+    }
+
+    // Tags (usually few)
+    for (_, target) in view.tags() {
+        if let Some(id) = target.local_target.as_normal() {
+            immutable.insert(id.clone());
+        }
+    }
+
+    immutable
+}
+
+/// Search for all bookmarks on ancestor commits using BFS
+/// Returns bookmarks sorted by distance (closest first)
+fn find_ancestor_bookmarks(
+    repo: &Arc<jj_lib::repo::ReadonlyRepo>,
+    view: &jj_lib::view::View,
+    wc_id: &jj_lib::backend::CommitId,
+    max_depth: usize,
+) -> Result<Vec<(String, usize)>> {
+    use std::collections::{HashMap, HashSet, VecDeque};
+
+    let mut queue: VecDeque<(jj_lib::backend::CommitId, usize)> = VecDeque::new();
+    let mut visited = HashSet::new();
+    let mut bookmarks_with_distances: HashMap<String, usize> = HashMap::new();
+
+    // Pre-compute immutable heads to stop traversal at trunk/tags/untracked remotes
+    let immutable_heads = find_immutable_heads(view);
+
+    // Start BFS from WC commit parents
+    let wc_commit = repo
+        .store()
+        .get_commit(wc_id)
+        .map_err(|e| Error::Jj(format!("get commit: {e}")))?;
+
+    for parent_id in wc_commit.parent_ids() {
+        queue.push_back((parent_id.clone(), 1));
+    }
+
+    while let Some((commit_id, depth)) = queue.pop_front() {
+        // Stop if we exceed max depth
+        if depth > max_depth {
+            continue;
+        }
+
+        // Skip if already visited
+        if !visited.insert(commit_id.clone()) {
+            continue;
+        }
+
+        // Collect all bookmarks at this commit
+        for (bookmark_name, _) in view.local_bookmarks_for_commit(&commit_id) {
+            let name = bookmark_name.as_str().to_string();
+            // Only record first (shortest) distance for each bookmark
+            bookmarks_with_distances.entry(name).or_insert(depth);
+        }
+
+        // Stop at immutable heads - don't traverse past trunk/tags/untracked remotes
+        if immutable_heads.contains(&commit_id) {
+            continue;
+        }
+
+        // Add parents to queue for next level
+        if depth < max_depth {
+            let commit = repo
+                .store()
+                .get_commit(&commit_id)
+                .map_err(|e| Error::Jj(format!("get commit: {e}")))?;
+
+            for parent_id in commit.parent_ids() {
+                queue.push_back((parent_id.clone(), depth + 1));
+            }
+        }
+    }
+
+    // Convert to vec and sort by distance
+    let mut result: Vec<(String, usize)> = bookmarks_with_distances.into_iter().collect();
+    result.sort_by_key(|(_, distance)| *distance);
+    Ok(result)
+}
+
 /// Collect JJ repo info from the given path
-pub fn collect(repo_root: &Path, id_length: usize) -> Result<JjInfo> {
+pub fn collect(repo_root: &Path, id_length: usize, ancestor_depth: usize) -> Result<JjInfo> {
     let settings = create_user_settings()?;
 
     let workspace = Workspace::load(
@@ -96,31 +207,49 @@ pub fn collect(repo_root: &Path, id_length: usize) -> Result<JjInfo> {
         .flatten()
         .is_some_and(|commits| commits.len() > 1);
 
-    // Find bookmark at WC commit
-    let bookmark: Option<String> = view
+    // Find bookmarks - first check direct bookmarks on WC (distance 0)
+    let mut bookmarks: Vec<(String, usize)> = view
         .local_bookmarks_for_commit(wc_id)
-        .next()
-        .map(|(name, _)| name.as_str().to_string());
+        .map(|(name, _)| (name.as_str().to_string(), 0))
+        .collect();
 
-    // Check remote sync status (only if we have a bookmark)
-    let (has_remote, is_synced) = if let Some(ref bm_name) = bookmark {
-        let name_matcher = StringPattern::exact(bm_name).to_matcher();
-        let remote_matcher = StringMatcher::All;
+    // Always search ancestors if enabled (useful for stacked PR context)
+    // Ancestor bookmarks are disjoint from direct bookmarks (different commits)
+    if ancestor_depth > 0 {
+        let ancestors = find_ancestor_bookmarks(&repo, view, wc_id, ancestor_depth)?;
+        bookmarks.extend(ancestors);
+    }
 
-        // Single pass over remote bookmarks
-        view.remote_bookmarks_matching(&name_matcher, &remote_matcher)
-            .filter(|(symbol, _)| symbol.remote.as_str() != "git")
-            .fold((false, false), |(_, synced), (_, remote_ref)| {
-                let this_synced = remote_ref.target.as_normal().is_some_and(|id| id == wc_id);
-                (true, synced || this_synced)
-            })
-    } else {
+    // Check remote sync status for first (closest) bookmark only
+    // For stacked PRs, this reflects whether current stack position needs pushing
+    let (has_remote, is_synced) = if bookmarks.is_empty() {
         (false, true)
+    } else {
+        let (bm_name, _) = &bookmarks[0];
+        let local_target = view.get_local_bookmark(RefName::new(bm_name));
+
+        let name_matcher = StringPattern::exact(bm_name).to_matcher();
+        let mut has_remote = false;
+        let mut is_synced = false;
+
+        for (symbol, remote_ref) in view.remote_bookmarks_matching(&name_matcher, &StringMatcher::All)
+        {
+            if symbol.remote.as_str() == "git" {
+                continue;
+            }
+            has_remote = true;
+            if remote_ref.target == *local_target {
+                is_synced = true;
+                break;
+            }
+        }
+
+        (has_remote, is_synced || !has_remote)
     };
 
     Ok(JjInfo {
         change_id,
-        bookmark,
+        bookmarks,
         empty_desc,
         conflict,
         divergent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,11 @@ struct Cli {
     #[arg(long, global = true)]
     id_length: Option<usize>,
 
-    /// Symbol prefix for JJ repos (default: "󱗆")
+    /// Max depth to search for ancestor bookmarks (0 = disabled, default: 10)
+    #[arg(long, global = true)]
+    ancestor_bookmark_depth: Option<usize>,
+
+    /// Symbol prefix for JJ repos (default: "󱗆")
     #[arg(long, global = true)]
     jj_symbol: Option<String>,
 
@@ -73,7 +77,7 @@ struct Cli {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 struct GitArgs {
-    /// Symbol prefix for Git repos (default: "")
+    /// Symbol prefix for Git repos (default: "")
     #[arg(long, global = true)]
     git_symbol: Option<String>,
     /// Hide "on {symbol}" prefix for Git repos
@@ -129,6 +133,7 @@ fn main() -> ExitCode {
     let config = Config::new(
         cli.truncate_name,
         cli.id_length,
+        cli.ancestor_bookmark_depth,
         jj_symbol,
         git_symbol,
         cli.no_symbol,
@@ -161,7 +166,8 @@ fn run_prompt(cwd: &Path, config: &Config) -> Option<String> {
     match result.repo_type {
         RepoType::Jj | RepoType::JjColocated => {
             let repo_root = result.repo_root?;
-            let info = jj::collect(&repo_root, config.id_length).ok()?;
+            let info =
+                jj::collect(&repo_root, config.id_length, config.ancestor_bookmark_depth).ok()?;
             Some(output::format_jj(&info, config))
         }
         #[cfg(feature = "git")]


### PR DESCRIPTION
Hey, love the project! Wanted to port one of the features from `starship-jj` with a small improvement.

When working on commits ahead of a bookmark, the prompt shows only the change ID with no context about which bookmark you branched from:
```bash
  on 󱗆 yzxv1234 [?]
```
  In jj workflows you're often working "above" bookmarks rather than directly on them, so knowing your position relative to tracked bookmarks is useful.

## Proposal:

  New `--show-ancestor-bookmark-depth` (we can probably come up with a better name) option searches parent commits for bookmarks and displays them with distance:
```bash
  on 󱗆 yzxv1234 (main~3) [?]
```bash

  Multiple bookmarks (from merge parents) are shown together:

```bash
  on 󱗆 yzxv1234 (feature~1, main~3)
```
  How it works

  - BFS traversal up the parent chain (handles merge commits)
  - Collects all bookmarks found within depth limit
  - Sorts by distance (closest first)
  - Visited set prevents re-walking commits in complex graphs

  Performance impact is negligible (~8ms with or without).

  Configuration
```
  # starship.toml
  [custom.jj]
  command = "jj-starship --show-ancestor-bookmark-depth 10"
  when = "jj-starship detect"
```
  Or via env var: `JJ_STARSHIP_SHOW_ANCESTOR_DEPTH=10`

  Disabled by default (0) for backward compatibility.
  
---

Draft implementation is in the diff.
