### PR TITLE
feat: add minimal unique prefix colouring for change_id

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -6,3 +6,5 @@ pub const PURPLE: &str = "\x1b[35m"; // Color 5: Magenta
 pub const GREEN: &str = "\x1b[32m"; // Color 2: Green
 pub const RED: &str = "\x1b[31m"; // Color 1: Red
 pub const BLUE: &str = "\x1b[34m"; // Color 4: Blue
+pub const BRIGHT_MAGENTA: &str = "\x1b[95m"; // Bright magenta (jj change_id prefix)
+pub const BRIGHT_BLACK: &str = "\x1b[90m"; // Bright black/gray (jj change_id rest)

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct DisplayConfig {
     pub show_id: bool,
     pub show_status: bool,
     pub show_color: bool,
+    /// Show unique prefix coloring for `change_id` (JJ only)
+    pub show_prefix_color: bool,
 }
 
 impl DisplayConfig {
@@ -27,6 +29,7 @@ impl DisplayConfig {
             show_id: true,
             show_status: true,
             show_color: true,
+            show_prefix_color: true,
         }
     }
 }
@@ -75,6 +78,7 @@ pub struct DisplayFlags {
     pub no_id: bool,
     pub no_status: bool,
     pub no_color: bool,
+    pub no_prefix_color: bool,
 }
 
 impl DisplayFlags {
@@ -85,6 +89,8 @@ impl DisplayFlags {
             show_id: !self.no_id && env::var(format!("{env_prefix}_ID")).is_err(),
             show_status: !self.no_status && env::var(format!("{env_prefix}_STATUS")).is_err(),
             show_color: !self.no_color && env::var(format!("{env_prefix}_COLOR")).is_err(),
+            show_prefix_color: !self.no_prefix_color
+                && env::var("JJ_STARSHIP_NO_PREFIX_COLOR").is_err(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,9 @@ struct Cli {
     /// Hide [status] for JJ repos
     #[arg(long, global = true)]
     no_jj_status: bool,
+    /// Disable unique prefix coloring for `change_id`
+    #[arg(long, global = true)]
+    no_prefix_color: bool,
 
     #[cfg(feature = "git")]
     #[command(flatten)]
@@ -114,6 +117,7 @@ fn main() -> ExitCode {
         no_id: cli.no_jj_id,
         no_status: cli.no_jj_status,
         no_color: cli.no_color,
+        no_prefix_color: cli.no_prefix_color,
     };
 
     #[cfg(feature = "git")]
@@ -125,6 +129,7 @@ fn main() -> ExitCode {
             no_id: cli.git.no_git_id,
             no_status: cli.git.no_git_status,
             no_color: cli.no_color,
+            no_prefix_color: false, // N/A for git
         },
     );
     #[cfg(not(feature = "git"))]


### PR DESCRIPTION
Hey, great project! 

I was missing the minimal prefix colouring from `jj log` in the prompt, so I added that here (with the help of Claude Opus 4.5). 

I'm not familiar with Rust, so relied pretty heavily on Claude here - let me know if you find that objectionable. I went over the generated code pretty closely, but since I'm a beginner to Rust it's very possible there's some non-idiomatic stuff in here. 

The unique coloured prefix shown in `jj log` depends on the default revset depth - hence we use the config-loading ability from jj-lib to read that value in order to colour the prefix in the same way. 

Before: 
<img width="667" height="91" alt="Screenshot 2025-12-23 at 1 26 46 PM" src="https://github.com/user-attachments/assets/772dccc0-b79d-44e5-9251-6c21b9c50c99" />

After: 

<img width="657" height="88" alt="Screenshot 2025-12-23 at 1 26 28 PM" src="https://github.com/user-attachments/assets/b843f47d-c10d-4f25-bc45-cb96bfe909a9" />
