### PR TITLE
feat: add version command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+fn run_cmd(cmd: &str, args: &[&str]) -> String {
+    std::process::Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string())
+}
+
+fn main() {
+    let jj_change = run_cmd(
+        "jj",
+        &["log", "-r", "@", "-T", "change_id.short(8)", "--no-graph"],
+    );
+    println!("cargo:rustc-env=JJ_CHANGE_ID={jj_change}");
+
+    let git_commit = run_cmd(
+        "jj",
+        &["log", "-r", "@", "-T", "commit_id.short(8)", "--no-graph"],
+    );
+    println!("cargo:rustc-env=GIT_COMMIT={git_commit}");
+
+    let date = run_cmd("date", &["-u", "+%Y-%m-%d"]);
+    println!("cargo:rustc-env=BUILD_DATE={date}");
+
+    println!("cargo:rerun-if-changed=.jj/repo/op_heads");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use std::process::ExitCode;
 
 #[derive(Parser)]
 #[command(name = "jj-starship")]
+#[command(version)]
 #[command(about = "Unified Git/JJ Starship prompt module")]
 #[allow(clippy::struct_excessive_bools)]
 struct Cli {
@@ -103,6 +104,8 @@ enum Command {
     Prompt,
     /// Exit 0 if in repo, 1 otherwise (for starship "when" condition)
     Detect,
+    /// Print version and build info
+    Version,
 }
 
 fn main() -> ExitCode {
@@ -162,6 +165,10 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         }
+        Command::Version => {
+            print_version();
+            ExitCode::SUCCESS
+        }
     }
 }
 
@@ -186,5 +193,27 @@ fn run_prompt(cwd: &Path, config: &Config) -> Option<String> {
         RepoType::None => None,
         // Catch disabled variants
         _ => None,
+    }
+}
+
+fn print_version() {
+    let version = env!("CARGO_PKG_VERSION");
+    let change_id = env!("JJ_CHANGE_ID");
+    let commit = env!("GIT_COMMIT");
+    let date = env!("BUILD_DATE");
+
+    println!("jj-starship {version}");
+    println!("change: {change_id}");
+    println!("commit: {commit}");
+    println!("built:  {date}");
+
+    let mut features = Vec::new();
+    #[cfg(feature = "git")]
+    features.push("git");
+
+    if features.is_empty() {
+        println!("features: none");
+    } else {
+        println!("features: {}", features.join(", "));
     }
 }


### PR DESCRIPTION
Adds `--version` flag and `version` subcommand.

- `jj-starship --version` → `jj-starship 0.3.1`
- `jj-starship version` → extended build info (JJ change_id, git commit, date, features)

Uses `build.rs` to capture JJ/git metadata at compile time via `cargo:rustc-env`.