### PR TITLE
chore: add repository URL to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Unified Git/JJ Starship prompt module"
+repository = "https://github.com/dmmulroy/jj-starship"
 license = "MIT"
 
 [[bin]]


### PR DESCRIPTION
Add repository URL to Cargo.toml for two reasons:
- Support installation via `cargo binstall`
- Make the repo link available on crates.io