### PR TITLE
fix: use target names for release assets (fixes #9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,31 +101,23 @@ jobs:
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
-            platform: darwin-x64
           - os: macos-latest
             target: aarch64-apple-darwin
-            platform: darwin-arm64
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            platform: linux-x64
           - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
-            platform: linux-arm64
             cross: true
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-            platform: linux-x64-musl
             cross: true
           - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
-            platform: linux-arm64-musl
             cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            platform: win32-x64
           - os: windows-latest
             target: aarch64-pc-windows-msvc
-            platform: win32-arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -176,7 +168,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}
+          name: ${{ matrix.target }}
           path: dist/
           if-no-files-found: error
 


### PR DESCRIPTION
Use matrix.target for artifact names so cargo-binstall can detect assets by default.