### PR TITLE
feat: add Nix flake support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         if: steps.filter.outputs.nix == 'true'
         uses: DeterminateSystems/magic-nix-cache-action@v8
         with:
-          use-flakehub: disabled
+          use-flakehub: false
 
       - name: Check flake
         if: steps.filter.outputs.nix == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,35 @@ jobs:
 
       - name: Build
         run: cargo build --release
+
+  nix:
+    name: Nix Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Nix-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            nix:
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'src/**'
+              - 'build.rs'
+
+      - name: Install Nix
+        if: steps.filter.outputs.nix == 'true'
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Setup Nix cache
+        if: steps.filter.outputs.nix == 'true'
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Check flake
+        if: steps.filter.outputs.nix == 'true'
+        run: nix flake check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Setup Nix cache
         if: steps.filter.outputs.nix == 'true'
         uses: DeterminateSystems/magic-nix-cache-action@v8
+        with:
+          use-flakehub: disabled
 
       - name: Check flake
         if: steps.filter.outputs.nix == 'true'

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: Update flake.lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # Monthly on the 1st
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "nix: update flake.lock"
+          pr-labels: |
+            dependencies
+            nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -30,6 +30,37 @@ cd jj-starship
 cargo install --path .
 ```
 
+### Nix
+
+```sh
+# Try it
+nix run github:dmmulroy/jj-starship
+
+# Install to profile
+nix profile install github:dmmulroy/jj-starship
+
+# Minimal build (no git support, smaller closure)
+nix run github:dmmulroy/jj-starship#jj-starship-no-git
+```
+
+Or add to your flake inputs:
+
+```nix
+{
+  inputs.jj-starship.url = "github:dmmulroy/jj-starship";
+
+  outputs = { self, nixpkgs, jj-starship, ... }: {
+    # Use the overlay
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [{
+        nixpkgs.overlays = [ jj-starship.overlays.default ];
+        environment.systemPackages = [ pkgs.jj-starship ];
+      }];
+    };
+  };
+}
+```
+
 ## Feature Flags
 
 The `git` feature is enabled by default. Disable to compile out the git backend:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766840161,
+        "narHash": "sha256-Ss/LHpJJsng8vz1Pe33RSGIWUOcqM1fjrehjUkdrWio=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3edc4a30ed3903fdf6f90c837f961fa6b49582d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+{
+  description = "Unified Git/JJ Starship prompt module optimized for latency";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    {
+      overlays.default = final: prev: {
+        jj-starship = self.packages.${final.system}.jj-starship;
+        jj-starship-no-git = self.packages.${final.system}.jj-starship-no-git;
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+
+        # Version suffix: use git rev if available, otherwise "dirty"
+        versionSuffix = if self ? rev then "-${builtins.substring 0 7 self.rev}" else "-dirty";
+
+        # Common source filtering for all variants
+        src = pkgs.lib.fileset.toSource {
+          root = ./.;
+          fileset = pkgs.lib.fileset.unions [
+            ./Cargo.toml
+            ./Cargo.lock
+            ./src
+            ./build.rs
+          ];
+        };
+
+        # Shared meta for all variants
+        meta = with pkgs.lib; {
+          description = "Unified Git/JJ Starship prompt module optimized for latency";
+          homepage = "https://github.com/dmmulroy/jj-starship";
+          changelog = "https://github.com/dmmulroy/jj-starship/releases/tag/v${version}";
+          license = licenses.mit;
+          maintainers = [ ]; # TODO: Add maintainer once registered in nixpkgs
+          mainProgram = "jj-starship";
+          platforms = platforms.unix;
+        };
+
+        # Build package with configurable features
+        mkJjStarship =
+          {
+            withGit ? true,
+          }:
+          pkgs.rustPlatform.buildRustPackage {
+            pname = "jj-starship" + pkgs.lib.optionalString (!withGit) "-no-git";
+            version = "${version}${versionSuffix}";
+
+            inherit src meta;
+
+            cargoLock.lockFile = ./Cargo.lock;
+
+            buildNoDefaultFeatures = !withGit;
+
+            nativeBuildInputs = [ pkgs.pkg-config ];
+
+            buildInputs =
+              with pkgs;
+              [
+                openssl
+                zlib
+              ]
+              ++ lib.optionals withGit [ libgit2 ]
+              ++ lib.optionals stdenv.hostPlatform.isDarwin [
+                # Security.framework - TLS/SSL and cryptographic operations for HTTPS git
+                # SystemConfiguration.framework - Network configuration (proxy, DNS)
+                apple-sdk
+                # libiconv - Character encoding conversion (separate from glibc on macOS)
+                libiconv
+              ];
+
+            doCheck = true;
+          };
+      in
+      {
+        packages = {
+          jj-starship = mkJjStarship { withGit = true; };
+          jj-starship-no-git = mkJjStarship { withGit = false; };
+          default = self.packages.${system}.jj-starship;
+        };
+
+        # Checks run by `nix flake check` - used in CI to verify builds
+        checks = {
+          # Ensure both package variants build successfully
+          jj-starship = self.packages.${system}.jj-starship;
+          jj-starship-no-git = self.packages.${system}.jj-starship-no-git;
+        };
+
+        # Development shell with Rust tooling
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.jj-starship ];
+          packages = with pkgs; [
+            rust-analyzer
+            rustfmt
+            clippy
+            cargo-watch
+          ];
+        };
+
+        # Formatter for `nix fmt`
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,8 @@ fn print_version() {
     println!("commit: {commit}");
     println!("built:  {date}");
 
-    let mut features = Vec::new();
+    #[allow(unused_mut)] // mut needed when features are enabled
+    let mut features: Vec<&str> = Vec::new();
     #[cfg(feature = "git")]
     features.push("git");
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,6 @@
 //! Output formatting for prompt strings
 
+#[cfg(feature = "git")]
 use std::borrow::Cow;
 #[cfg(feature = "git")]
 use std::fmt::Write;


### PR DESCRIPTION
Added a `flake.nix` to the package, allowing Nix users to easily pull the package in their configs. Also added a `flake check` for builds to CI, and a monthly CI job for auto-updating `flake.lock` dependencies (though this is optional, let me know if you'd like it removed). I tested the CI workflows and pulled the package from my Mac on nix-darwin.

Also fixed two small Clippy warnings due to the way the feature flags worked.