### PR TITLE
Update empty message status symbol and criteria for display

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -6,5 +6,6 @@ pub const PURPLE: &str = "\x1b[35m"; // Color 5: Magenta
 pub const GREEN: &str = "\x1b[32m"; // Color 2: Green
 pub const RED: &str = "\x1b[31m"; // Color 1: Red
 pub const BLUE: &str = "\x1b[34m"; // Color 4: Blue
+pub const YELLOW: &str = "\x1b[33m"; // Color 3: Yellow (jj "(no description set)")
 pub const BRIGHT_MAGENTA: &str = "\x1b[95m"; // Bright magenta (jj change_id prefix)
 pub const BRIGHT_BLACK: &str = "\x1b[90m"; // Bright black/gray (jj change_id rest)

--- a/src/jj.rs
+++ b/src/jj.rs
@@ -28,6 +28,8 @@ pub struct JjInfo {
     pub bookmarks: Vec<(String, usize)>,
     /// Description is empty (needs commit message)
     pub empty_desc: bool,
+    /// Commit has no changes (tree matches parent)
+    pub empty_commit: bool,
     /// Has conflicts in tree
     pub conflict: bool,
     /// Multiple commits for same `change_id`
@@ -214,6 +216,11 @@ pub fn collect(repo_root: &Path, id_length: usize, ancestor_depth: usize) -> Res
     // Empty description check
     let empty_desc = commit.description().trim().is_empty();
 
+    // Empty commit check
+    let empty_commit = commit
+        .is_empty(repo.as_ref())
+        .map_err(|e| Error::Jj(format!("check if commit is empty: {e}")))?;
+
     // Conflict check
     let conflict = commit.has_conflict();
 
@@ -270,6 +277,7 @@ pub fn collect(repo_root: &Path, id_length: usize, ancestor_depth: usize) -> Res
         change_id_prefix_len,
         bookmarks,
         empty_desc,
+        empty_commit,
         conflict,
         divergent,
         has_remote,

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 #[cfg(feature = "git")]
 use std::fmt::Write;
 
-use crate::color::{BLUE, BRIGHT_BLACK, BRIGHT_MAGENTA, GREEN, PURPLE, RED, RESET};
+use crate::color::{BLUE, BRIGHT_BLACK, BRIGHT_MAGENTA, GREEN, PURPLE, RED, RESET, YELLOW};
 use crate::config::Config;
 #[cfg(feature = "git")]
 use crate::git::GitInfo;
@@ -96,7 +96,7 @@ pub fn format_jj(info: &JjInfo, config: &Config) -> String {
         out.push_str(&format_segment(&bookmarks_text, GREEN, display.show_color));
     }
 
-    // Status indicators in red (priority: ! > ⇔ > ? > ⇡)
+    // Status indicators (priority: ! > ⇔ > ∅ > ⇡)
     if display.show_status {
         let mut status = String::with_capacity(8);
         if info.conflict {
@@ -105,8 +105,9 @@ pub fn format_jj(info: &JjInfo, config: &Config) -> String {
         if info.divergent {
             status.push('⇔');
         }
-        if info.empty_desc {
-            status.push('?');
+        // Only show ∅ for non-empty commits with empty description
+        if info.empty_desc && !info.empty_commit {
+            status.push('∅');
         }
         if info.has_remote && !info.is_synced {
             status.push('⇡');
@@ -117,7 +118,9 @@ pub fn format_jj(info: &JjInfo, config: &Config) -> String {
                 out.push(' ');
             }
             let status_text = format!("[{}]", &status);
-            out.push_str(&format_segment(&status_text, RED, display.show_color));
+            // Use yellow if status is only ∅, otherwise red
+            let color = if status == "∅" { YELLOW } else { RED };
+            out.push_str(&format_segment(&status_text, color, display.show_color));
         }
     }
 
@@ -238,6 +241,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: true,
@@ -259,6 +263,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![],
             empty_desc: true,
+            empty_commit: false,
             conflict: true,
             divergent: false,
             has_remote: false,
@@ -267,7 +272,7 @@ mod tests {
         assert_eq!(
             format_jj(&info, &no_symbol_config()),
             format!(
-                "on {BLUE}{RESET}{BRIGHT_MAGENTA}yzxv{RESET}{BRIGHT_BLACK}1234{RESET} {RED}[!?]{RESET}"
+                "on {BLUE}{RESET}{BRIGHT_MAGENTA}yzxv{RESET}{BRIGHT_BLACK}1234{RESET} {RED}[!∅]{RESET}"
             )
         );
     }
@@ -279,6 +284,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: true,
@@ -310,6 +316,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("very-long-bookmark-name".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -330,6 +337,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 3)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: true,
@@ -350,6 +358,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -368,6 +377,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("feature".into(), 1), ("main".into(), 2)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -388,6 +398,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: true,
@@ -421,6 +432,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -458,6 +470,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -489,6 +502,48 @@ mod tests {
     }
 
     #[test]
+    fn test_jj_format_empty_commit_empty_desc() {
+        // Empty commit with empty description: no status should be displayed
+        let info = JjInfo {
+            change_id: "yzxv1234".into(),
+            change_id_prefix_len: 4,
+            bookmarks: vec![],
+            empty_desc: true,
+            empty_commit: true,
+            conflict: false,
+            divergent: false,
+            has_remote: false,
+            is_synced: true,
+        };
+        assert_eq!(
+            format_jj(&info, &no_symbol_config()),
+            format!("on {BLUE}{RESET}{BRIGHT_MAGENTA}yzxv{RESET}{BRIGHT_BLACK}1234{RESET}")
+        );
+    }
+
+    #[test]
+    fn test_jj_format_non_empty_commit_empty_desc() {
+        // Non-empty commit with empty description: show ∅ in yellow
+        let info = JjInfo {
+            change_id: "yzxv1234".into(),
+            change_id_prefix_len: 4,
+            bookmarks: vec![],
+            empty_desc: true,
+            empty_commit: false,
+            conflict: false,
+            divergent: false,
+            has_remote: false,
+            is_synced: true,
+        };
+        assert_eq!(
+            format_jj(&info, &no_symbol_config()),
+            format!(
+                "on {BLUE}{RESET}{BRIGHT_MAGENTA}yzxv{RESET}{BRIGHT_BLACK}1234{RESET} {YELLOW}[∅]{RESET}"
+            )
+        );
+    }
+
+    #[test]
     fn test_jj_format_direct_bookmark_distance_zero() {
         // Verifies that when WC has a direct bookmark (distance 0),
         // it shows without ~N suffix even with ancestor search enabled
@@ -497,6 +552,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0)], // distance 0 = directly on WC
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -587,6 +643,7 @@ mod tests {
                 ("develop".into(), 4),
             ],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -619,6 +676,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0), ("feat".into(), 1)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -656,6 +714,7 @@ mod tests {
                 ("d".into(), 3),
             ],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -687,6 +746,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("main".into(), 0), ("feat".into(), 1), ("other".into(), 2)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -722,6 +782,7 @@ mod tests {
                 ("staging".into(), 2),
             ],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -757,6 +818,7 @@ mod tests {
                 ("staging".into(), 2),
             ],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,
@@ -789,6 +851,7 @@ mod tests {
             change_id_prefix_len: 4,
             bookmarks: vec![("dmmulroy/very-long-feature-name".into(), 0)],
             empty_desc: false,
+            empty_commit: false,
             conflict: false,
             divergent: false,
             has_remote: false,


### PR DESCRIPTION
* Do not display any status if both the commit and message are empty.
* Display the ∅ status if the commit is non-empty but the message is empty.

Fixes #15