### PR TITLE
flake.nix: replace deprecated 'system' alias in overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,8 @@
     }:
     {
       overlays.default = final: prev: {
-        jj-starship = self.packages.${final.system}.jj-starship;
-        jj-starship-no-git = self.packages.${final.system}.jj-starship-no-git;
+        jj-starship = self.packages.${final.stdenv.hostPlatform.system}.jj-starship;
+        jj-starship-no-git = self.packages.${final.stdenv.hostPlatform.system}.jj-starship-no-git;
       };
     }
     // flake-utils.lib.eachDefaultSystem (


### PR DESCRIPTION
## Description
This PR fixes the following evaluation warning caused by the recent deprecation of the `system` attribute in Nixpkgs:
> `evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

## Changes
- Replaced `final.system` with `final.stdenv.hostPlatform.system` in `overlays.default`.